### PR TITLE
Add --ci flag for Continuous Integration

### DIFF
--- a/package-bin.js
+++ b/package-bin.js
@@ -21,7 +21,7 @@ const mod = {
 		require('child_process').spawn(mod.DataMochaPath() || 'mocha', [].concat.apply([], [
 			'**/*-tests.js',
 			'--exclude', '**/+(node_modules|__*)/**',
-			'--watch',
+			args.includes('--ci') ? [] : '--watch',
 			'--file', require('path').join(__dirname, 'mocha-start.js'),
 			require('fs').existsSync(require('path').join(process.cwd(), 'mocha-start.js')) ? ['--file', require('path').join(process.cwd(), 'mocha-start.js')] : [],
 			args.includes('--reporter') ? [] : ['--reporter', 'min'],
@@ -35,6 +35,8 @@ const mod = {
 				env: Object.assign(process.env, {
 					npm_lifecycle_script: 'olsk-spec',
 				}),
+			}).on('exit', function (code) {
+				process.exit(code);
 			});
 	},
 


### PR DESCRIPTION
This PR adds a new `--ci` flag to the `olsk-spec` command in order to run tests on Continuous Integration environments.

The only thing it does is removing the `--watch` flag so that tests end after executing once. Something else I had to do is echo the exit code of the child process to the main thread. This was necessary because most CI environments depend on exit codes to determine if a command was successful or not. I don't think this change should affect your development workflow, given that on success it will end with a successful exit code and when you use it for development the process doesn't exit anyways.

I've noticed there is also a `olsk-spec-ui` command, but I'm not sure what it does because you don't seem to be using it in any project (at least, it's not configured on any npm script). I tried running it locally with [hyperdraft](https://github.com/wikiavec/hyperdraft) but all the tests failed, so I must be doing something wrong.