### PR TITLE
Remove supervisor

### DIFF
--- a/package-bin.js
+++ b/package-bin.js
@@ -45,7 +45,7 @@ const mod = {
 			testPaths,
 			
 			args.includes('--ci') ? [] : '--watch',
-			'--watch-files', sourcePaths,
+			'--watch-files', sourcePaths.join(','),
 
 			'--timeout', '1000',
 

--- a/package.json
+++ b/package.json
@@ -28,9 +28,6 @@
     "// BROWSER TESTING": null,
     "zombie": "latest",
 
-    "// COMPLEX FILE WATCHING": null,
-    "supervisor": "latest",
-
     "// ENV GUARD": null,
     "OLSKEnv": "olsk/OLSKEnv",
     


### PR DESCRIPTION
This attempts to use `mocha` directly for interface tests, which should make it simpler to incorporate @NoelDeMartin's change from #1. At the moment there are errors when running because seems that mocha tries to *run* the files specified in `--watch-files`. I'm not sure why this happens wasn't able to find it in the code, so I have asked in the [Mocha Gitter](https://gitter.im/mochajs/mocha) how to work around this. Will try to advance this over time.